### PR TITLE
Improve docs example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,27 +57,29 @@ function perf_cart_index_fast!(X, Y)
         Val(CI),
     )
 end;
-function perf_cart_index!(X, Y)
+function perf_cart_index!(X, Y, CI)
     x1 = X.x1;
     nitems = length(parent(x1));
     max_threads = 256; # can be higher if conditions permit
     nthreads = min(max_threads, nitems);
     nblocks = cld(nitems, nthreads);
-    CI = CartesianIndices(size(x1));
     CUDA.@cuda threads=nthreads blocks=nblocks name="cartesian" perf_cart_index_kernel!(
         X,
         Y,
         Val(nitems),
-        Val(CI),
+        CI,
     )
 end;
-function perf_cart_index_kernel!(X, Y, ::Val{nitems}, ::Val{CI}) where {nitems, CI}
+unval(::Val{CI}) where {CI} = CI
+unval(CI) = CI
+function perf_cart_index_kernel!(X, Y, ::Val{nitems}, valci) where {nitems}
     (; x1, x2, x3, x4) = X
     (; y1) = Y
     @inbounds begin
         _i = CUDA.threadIdx().x +
           (CUDA.blockIdx().x - Int32(1)) * CUDA.blockDim().x
         if _i ≤ nitems
+            CI = unval(valci)
             i = CI[_i]
             # more flops makes them much closer
             # y1[i] = x1[i] + x2[i] + x3[i] + x4[i]
@@ -97,6 +99,8 @@ array_size = (50, 5, 5, 6, 5400); # array
 X = get_arrays(:x, CUDA.CuArray, Float64, array_size);
 Y = get_arrays(:y, CUDA.CuArray, Float64, array_size);
 
+fast_ci(x) = FastCartesianIndices(map(Int32, size(x)))
+
 CUDA.@profile begin
     perf_linear_index!(X, Y)
     perf_linear_index!(X, Y)
@@ -105,17 +109,31 @@ CUDA.@profile begin
 end
 
 CUDA.@profile begin
-    perf_cart_index!(X, Y)
-    perf_cart_index!(X, Y)
-    perf_cart_index!(X, Y)
-    perf_cart_index!(X, Y)
+    perf_cart_index!(X, Y, CartesianIndices(X.x1))
+    perf_cart_index!(X, Y, CartesianIndices(X.x1))
+    perf_cart_index!(X, Y, CartesianIndices(X.x1))
+    perf_cart_index!(X, Y, CartesianIndices(X.x1))
 end
 
 CUDA.@profile begin
-    perf_cart_index_fast!(X, Y)
-    perf_cart_index_fast!(X, Y)
-    perf_cart_index_fast!(X, Y)
-    perf_cart_index_fast!(X, Y)
+    perf_cart_index!(X, Y, Val(CartesianIndices(X.x1)))
+    perf_cart_index!(X, Y, Val(CartesianIndices(X.x1)))
+    perf_cart_index!(X, Y, Val(CartesianIndices(X.x1)))
+    perf_cart_index!(X, Y, Val(CartesianIndices(X.x1)))
+end
+
+CUDA.@profile begin
+    perf_cart_index!(X, Y, fast_ci(X.x1))
+    perf_cart_index!(X, Y, fast_ci(X.x1))
+    perf_cart_index!(X, Y, fast_ci(X.x1))
+    perf_cart_index!(X, Y, fast_ci(X.x1))
+end
+
+CUDA.@profile begin
+    perf_cart_index!(X, Y, Val(fast_ci(X.x1)))
+    perf_cart_index!(X, Y, Val(fast_ci(X.x1)))
+    perf_cart_index!(X, Y, Val(fast_ci(X.x1)))
+    perf_cart_index!(X, Y, Val(fast_ci(X.x1)))
 end
 ```
 
@@ -131,23 +149,42 @@ Device-side activity: GPU was busy for 1.5 ms (0.02% of the trace)
 └──────────┴────────────┴───────┴──────────────────────────────────────┴────────┘
 ```
 
-For `perf_cart_index!`
+For `perf_cart_index!(X, Y, CartesianIndices(...))`
 ```julia
-Device-side activity: GPU was busy for 6.94 ms (1.58% of the trace)
-┌──────────┬────────────┬───────┬────────────────────────────────────┬───────────┐
-│ Time (%) │ Total time │ Calls │ Time distribution                  │ Name      │
-├──────────┼────────────┼───────┼────────────────────────────────────┼───────────┤
-│    1.58% │    6.94 ms │     4 │   1.74 ms ± 2.42   (  0.53 ‥ 5.36) │ cartesian │
-└──────────┴────────────┴───────┴────────────────────────────────────┴───────────┘
-```
-
-For `perf_cart_index_fast!`
-
-```julia
-Device-side activity: GPU was busy for 1.55 ms (0.38% of the trace)
+Device-side activity: GPU was busy for 3.31 ms (0.47% of the trace)
 ┌──────────┬────────────┬───────┬──────────────────────────────────────┬───────────┐
 │ Time (%) │ Total time │ Calls │ Time distribution                    │ Name      │
 ├──────────┼────────────┼───────┼──────────────────────────────────────┼───────────┤
-│    0.38% │    1.55 ms │     4 │ 387.97 µs ± 6.49   (379.32 ‥ 393.63) │ cartesian │
+│    0.47% │    3.31 ms │     4 │ 828.62 µs ± 0.63   (828.03 ‥ 829.46) │ cartesian │
+└──────────┴────────────┴───────┴──────────────────────────────────────┴───────────┘
+```
+
+For `perf_cart_index!(X, Y, Val(CartesianIndices(...)))`
+```julia
+Device-side activity: GPU was busy for 2.61 ms (1.84% of the trace)
+┌──────────┬────────────┬───────┬──────────────────────────────────────┬───────────┐
+│ Time (%) │ Total time │ Calls │ Time distribution                    │ Name      │
+├──────────┼────────────┼───────┼──────────────────────────────────────┼───────────┤
+│    1.84% │    2.61 ms │     4 │  651.9 µs ± 0.12   (651.84 ‥ 652.07) │ cartesian │
+└──────────┴────────────┴───────┴──────────────────────────────────────┴───────────┘
+```
+
+For `perf_cart_index!(X, Y, fast_ci(...))`
+```julia
+Device-side activity: GPU was busy for 2.08 ms (0.48% of the trace)
+┌──────────┬────────────┬───────┬──────────────────────────────────────┬───────────┐
+│ Time (%) │ Total time │ Calls │ Time distribution                    │ Name      │
+├──────────┼────────────┼───────┼──────────────────────────────────────┼───────────┤
+│    0.48% │    2.08 ms │     4 │ 519.45 µs ± 0.3    (519.04 ‥ 519.75) │ cartesian │
+└──────────┴────────────┴───────┴──────────────────────────────────────┴───────────┘
+```
+
+For `perf_cart_index!(X, Y, Val(fast_ci(...)))`
+```julia
+Device-side activity: GPU was busy for 1.64 ms (0.86% of the trace)
+┌──────────┬────────────┬───────┬──────────────────────────────────────┬───────────┐
+│ Time (%) │ Total time │ Calls │ Time distribution                    │ Name      │
+├──────────┼────────────┼───────┼──────────────────────────────────────┼───────────┤
+│    0.86% │    1.64 ms │     4 │ 408.77 µs ± 9.91   (397.44 ‥ 420.33) │ cartesian │
 └──────────┴────────────┴───────┴──────────────────────────────────────┴───────────┘
 ```


### PR DESCRIPTION
This PR simplifies the docs example and breaks down the performance for:

 - `CartesianIndices(...)`
 - `Val(CartesianIndices(...))`
 - `FastCartesianIndices(...)`
 - `Val(FastCartesianIndices(...))`